### PR TITLE
fix: add Flutter CI blueprint actions

### DIFF
--- a/ci/flutter/artifacts/action.yml
+++ b/ci/flutter/artifacts/action.yml
@@ -1,0 +1,88 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Upload Flutter Artifacts
+author: cloudopsworks
+description: Upload Flutter build artifacts and deploy-compatible target bundles
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  project_path:
+    required: false
+    default: '.'
+    description: 'Flutter project path relative to source_path'
+  platform_type:
+    required: true
+    description: 'android or ios'
+  artifact_paths_json:
+    required: true
+    description: 'JSON array of artifact paths relative to project directory'
+  workflow_artifact_name:
+    required: true
+    description: 'Build artifact upload name'
+  target_artifact_name:
+    required: true
+    description: 'Target diagnostics artifact upload name'
+  artifact_manifest_path:
+    required: false
+    default: ''
+    description: 'Path to artifact manifest'
+  if_no_files_found:
+    required: false
+    default: 'error'
+    description: 'upload-artifact if-no-files-found behavior'
+outputs:
+  uploaded_artifact_names_json:
+    description: 'JSON array of uploaded artifact names'
+    value: ${{ steps.prepare.outputs.uploaded_artifact_names_json }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Prepare artifact upload lists
+      id: prepare
+      shell: bash
+      working-directory: ${{ inputs.source_path }}/${{ inputs.project_path }}
+      env:
+        ARTIFACT_PATHS_JSON: ${{ inputs.artifact_paths_json }}
+        MANIFEST_PATH: ${{ inputs.artifact_manifest_path }}
+      run: |
+        set -euo pipefail
+        mkdir -p build/flutter-upload build/flutter-target
+        : > build/flutter-upload/files.txt
+        while IFS= read -r f; do
+          [[ -n "$f" && -f "$f" ]] && echo "$f" >> build/flutter-upload/files.txt
+        done < <(jq -r '.[]?' <<<"$ARTIFACT_PATHS_JSON")
+        if [[ -n "$MANIFEST_PATH" && -f "$GITHUB_WORKSPACE/$MANIFEST_PATH" ]]; then
+          cp "$GITHUB_WORKSPACE/$MANIFEST_PATH" build/flutter-upload/artifact-manifest.json
+        elif [[ -n "$MANIFEST_PATH" && -f "$MANIFEST_PATH" ]]; then
+          cp "$MANIFEST_PATH" build/flutter-upload/artifact-manifest.json
+        fi
+        if [[ ! -s build/flutter-upload/files.txt ]]; then
+          echo "::error::No artifact files found from artifact_paths_json"
+          exit 1
+        fi
+        tar -cf build/flutter-target/source_artifacts_target.tar \
+          --exclude='build' --exclude='.dart_tool' --exclude='android/.gradle' --exclude='ios/Pods' --exclude='ios/Flutter/ephemeral' \
+          . 2>/dev/null || tar -cf build/flutter-target/source_artifacts_target.tar .
+        echo "uploaded_artifact_names_json=[\"${{ inputs.workflow_artifact_name }}\",\"${{ inputs.target_artifact_name }}\"]" >> "$GITHUB_OUTPUT"
+
+    - name: Upload Flutter build artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.workflow_artifact_name }}
+        path: |
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-upload/files.txt
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-upload/artifact-manifest.json
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/app/outputs/**/*.apk
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/app/outputs/**/*.aab
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/ios/**/*.ipa
+          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/ios/smoke/*.zip
+        if-no-files-found: ${{ inputs.if_no_files_found }}
+
+    - name: Upload Flutter target bundle
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.target_artifact_name }}
+        path: ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-target/source_artifacts_target.tar
+        if-no-files-found: error

--- a/ci/flutter/build/action.yml
+++ b/ci/flutter/build/action.yml
@@ -1,0 +1,322 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Build Flutter Project
+author: cloudopsworks
+description: Build one Flutter platform target and emit artifact metadata
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  project_path:
+    required: false
+    default: '.'
+    description: 'Flutter project path relative to source_path'
+  platform_type:
+    required: true
+    description: 'android or ios'
+  bot_user:
+    required: false
+    default: ''
+    description: 'Bot user'
+  token:
+    required: false
+    default: ${{ github.token }}
+    description: 'GitHub token'
+  project_key:
+    required: true
+    description: 'Project key'
+  semver_override:
+    required: false
+    default: ''
+    description: 'Override semantic version'
+  build_number:
+    required: false
+    default: ${{ github.run_number }}
+    description: 'Monotonic build number'
+  flutter_target:
+    required: false
+    default: 'lib/main.dart'
+    description: 'Flutter target'
+  flutter_build_mode:
+    required: false
+    default: 'release'
+    description: 'debug, profile, or release'
+  dart_defines_json:
+    required: false
+    default: '[]'
+    description: 'JSON array of KEY=VALUE dart defines'
+  flutter_extra_args:
+    required: false
+    default: ''
+    description: 'Extra Flutter arguments'
+  android_artifact_types:
+    required: false
+    default: '["apk"]'
+    description: 'JSON array: apk, appbundle'
+  android_split_per_abi:
+    required: false
+    default: 'false'
+    description: 'Whether to split APKs per ABI'
+  android_build_args:
+    required: false
+    default: ''
+    description: 'Extra Android build args'
+  android_sdk:
+    required: false
+    default: 'android'
+    description: 'Android artifact/deploy dimension'
+  android_destination:
+    required: false
+    default: 'universal'
+    description: 'Android artifact/deploy destination'
+  ios_codesign:
+    required: false
+    default: 'false'
+    description: 'Whether to build a signed IPA'
+  ios_export_method:
+    required: false
+    default: 'ad-hoc'
+    description: 'iOS export method'
+  ios_export_options_plist:
+    required: false
+    default: ''
+    description: 'iOS export options plist path'
+  ios_scheme:
+    required: false
+    default: 'Runner'
+    description: 'Xcode scheme for artifact/deploy naming'
+  ios_sdk:
+    required: false
+    default: 'iphoneos'
+    description: 'iOS SDK for artifact/deploy naming'
+  ios_destination:
+    required: false
+    default: 'generic/platform=iOS'
+    description: 'iOS destination for artifact/deploy naming'
+  ios_configuration:
+    required: false
+    default: 'Release'
+    description: 'iOS configuration'
+  build_certificate_b64:
+    required: false
+    default: ''
+    description: 'Base64 encoded signing certificate'
+  build_certificate_pass:
+    required: false
+    default: ''
+    description: 'Signing certificate password'
+  build_provision_profile_b64:
+    required: false
+    default: ''
+    description: 'Base64 encoded provisioning profile'
+  keychain_password:
+    required: false
+    default: ''
+    description: 'Temporary keychain password'
+  build_export_options_plist:
+    required: false
+    default: ''
+    description: 'Base64 encoded export options plist'
+outputs:
+  semver:
+    description: 'Resolved semantic version'
+    value: ${{ steps.build.outputs.semver }}
+  package_name:
+    description: 'Project/package name'
+    value: ${{ steps.build.outputs.package_name }}
+  platform_type:
+    description: 'Built platform'
+    value: ${{ inputs.platform_type }}
+  artifact_paths_json:
+    description: 'JSON array of artifact paths'
+    value: ${{ steps.build.outputs.artifact_paths_json }}
+  artifact_manifest_json:
+    description: 'JSON artifact manifest'
+    value: ${{ steps.build.outputs.artifact_manifest_json }}
+  deployable_artifact_type:
+    description: 'apk, ipa, or none'
+    value: ${{ steps.build.outputs.deployable_artifact_type }}
+  workflow_artifact_name:
+    description: 'Deploy-compatible workflow artifact name'
+    value: ${{ steps.build.outputs.workflow_artifact_name }}
+  target_artifact_name:
+    description: 'Deploy-compatible target artifact name'
+    value: ${{ steps.build.outputs.target_artifact_name }}
+  artifact_manifest_path:
+    description: 'Path to manifest file'
+    value: ${{ steps.build.outputs.artifact_manifest_path }}
+  ios_ipa_available:
+    description: 'Whether IPA exists'
+    value: ${{ steps.build.outputs.ios_ipa_available }}
+  android_apk_available:
+    description: 'Whether APK exists'
+    value: ${{ steps.build.outputs.android_apk_available }}
+  android_aab_available:
+    description: 'Whether AAB exists'
+    value: ${{ steps.build.outputs.android_aab_available }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Build Flutter platform
+      id: build
+      shell: bash
+      working-directory: ${{ inputs.source_path }}/${{ inputs.project_path }}
+      env:
+        PLATFORM_TYPE: ${{ inputs.platform_type }}
+        SEMVER_OVERRIDE: ${{ inputs.semver_override }}
+        BUILD_NUMBER: ${{ inputs.build_number }}
+        BUILD_MODE: ${{ inputs.flutter_build_mode }}
+        FLUTTER_TARGET: ${{ inputs.flutter_target }}
+        DART_DEFINES_JSON: ${{ inputs.dart_defines_json }}
+        FLUTTER_EXTRA_ARGS: ${{ inputs.flutter_extra_args }}
+        ANDROID_ARTIFACT_TYPES: ${{ inputs.android_artifact_types }}
+        ANDROID_SPLIT_PER_ABI: ${{ inputs.android_split_per_abi }}
+        ANDROID_BUILD_ARGS: ${{ inputs.android_build_args }}
+        ANDROID_SDK: ${{ inputs.android_sdk }}
+        ANDROID_DESTINATION: ${{ inputs.android_destination }}
+        IOS_CODESIGN: ${{ inputs.ios_codesign }}
+        IOS_EXPORT_METHOD: ${{ inputs.ios_export_method }}
+        IOS_EXPORT_OPTIONS_PLIST: ${{ inputs.ios_export_options_plist }}
+        IOS_SCHEME: ${{ inputs.ios_scheme }}
+        IOS_SDK: ${{ inputs.ios_sdk }}
+        IOS_DESTINATION: ${{ inputs.ios_destination }}
+        BUILD_CERTIFICATE_B64: ${{ inputs.build_certificate_b64 }}
+        BUILD_CERTIFICATE_PASS: ${{ inputs.build_certificate_pass }}
+        BUILD_PROVISION_PROFILE_B64: ${{ inputs.build_provision_profile_b64 }}
+        KEYCHAIN_PASSWORD: ${{ inputs.keychain_password }}
+        BUILD_EXPORT_OPTIONS_PLIST: ${{ inputs.build_export_options_plist }}
+      run: |
+        set -euo pipefail
+        mode_flag="--release"
+        case "$BUILD_MODE" in
+          debug) mode_flag="--debug" ;;
+          profile) mode_flag="--profile" ;;
+          release|Release|"") mode_flag="--release" ;;
+          *) echo "::error::Unsupported flutter_build_mode: $BUILD_MODE"; exit 1 ;;
+        esac
+        semver="$SEMVER_OVERRIDE"
+        if [[ -z "$semver" ]]; then
+          if [[ -f Makefile ]]; then
+            make version >/tmp/flutter-version.log 2>&1 || cat /tmp/flutter-version.log
+          fi
+          if [[ -f VERSION ]]; then
+            semver=$(tr -d '[:space:]' < VERSION)
+          elif [[ -f pubspec.yaml ]]; then
+            semver=$(yq e '.version // "0.0.0+0"' pubspec.yaml | cut -d+ -f1)
+          else
+            semver="0.0.0"
+          fi
+        fi
+        build_name="${semver#v}"
+        package_name="${{ inputs.project_key }}"
+        if [[ -f pubspec.yaml ]]; then
+          package_name=$(yq e '.name // "${{ inputs.project_key }}"' pubspec.yaml)
+        fi
+        dart_args=()
+        while IFS= read -r define; do
+          [[ -n "$define" && "$define" != "null" ]] && dart_args+=("--dart-define=$define")
+        done < <(jq -r '.[]?' <<<"$DART_DEFINES_JSON")
+        common_args=("$mode_flag" "--target" "$FLUTTER_TARGET" "--build-name" "$build_name" "--build-number" "$BUILD_NUMBER")
+        common_args+=("${dart_args[@]}")
+        if [[ -n "$FLUTTER_EXTRA_ARGS" ]]; then
+          # shellcheck disable=SC2206
+          extra=( $FLUTTER_EXTRA_ARGS )
+          common_args+=("${extra[@]}")
+        fi
+        flutter pub get
+
+        if [[ "$IOS_CODESIGN" == "true" && "$PLATFORM_TYPE" == "ios" && -n "$BUILD_CERTIFICATE_B64" ]]; then
+          security create-keychain -p "${KEYCHAIN_PASSWORD:-temporary-password}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD:-temporary-password}" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$BUILD_CERTIFICATE_B64" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "$BUILD_CERTIFICATE_PASS" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD:-temporary-password}" build.keychain
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          if [[ -n "$BUILD_PROVISION_PROFILE_B64" ]]; then
+            echo "$BUILD_PROVISION_PROFILE_B64" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/profile.mobileprovision"
+          fi
+          if [[ -n "$BUILD_EXPORT_OPTIONS_PLIST" ]]; then
+            echo "$BUILD_EXPORT_OPTIONS_PLIST" | base64 --decode > exportOptions.plist
+            IOS_EXPORT_OPTIONS_PLIST="exportOptions.plist"
+          fi
+        fi
+
+        artifacts=()
+        deployable="none"
+        if [[ "$PLATFORM_TYPE" == "android" ]]; then
+          if jq -e 'index("apk")' <<<"$ANDROID_ARTIFACT_TYPES" >/dev/null; then
+            args=("${common_args[@]}")
+            [[ "$ANDROID_SPLIT_PER_ABI" == "true" ]] && args+=("--split-per-abi")
+            if [[ -n "$ANDROID_BUILD_ARGS" ]]; then
+              # shellcheck disable=SC2206
+              extra_android=( $ANDROID_BUILD_ARGS )
+              args+=("${extra_android[@]}")
+            fi
+            flutter build apk "${args[@]}"
+          fi
+          if jq -e 'index("appbundle")' <<<"$ANDROID_ARTIFACT_TYPES" >/dev/null; then
+            args=("${common_args[@]}")
+            if [[ -n "$ANDROID_BUILD_ARGS" ]]; then
+              # shellcheck disable=SC2206
+              extra_android=( $ANDROID_BUILD_ARGS )
+              args+=("${extra_android[@]}")
+            fi
+            flutter build appbundle "${args[@]}"
+          fi
+          while IFS= read -r f; do artifacts+=("$f"); done < <(find build/app/outputs -type f \( -name '*.apk' -o -name '*.aab' \) 2>/dev/null | sort)
+          apk_count=$(printf '%s\n' "${artifacts[@]:-}" | grep -c '\.apk$' || true)
+          aab_count=$(printf '%s\n' "${artifacts[@]:-}" | grep -c '\.aab$' || true)
+          if [[ "$apk_count" -eq 1 && "$ANDROID_SPLIT_PER_ABI" != "true" ]]; then deployable="apk"; fi
+          normalized=$(echo "${ANDROID_SDK}_${ANDROID_DESTINATION}" | tr ' ,:=/' '-')
+        elif [[ "$PLATFORM_TYPE" == "ios" ]]; then
+          if [[ "$IOS_CODESIGN" == "true" ]]; then
+            args=("${common_args[@]}")
+            if [[ -n "$IOS_EXPORT_OPTIONS_PLIST" ]]; then
+              args+=("--export-options-plist" "$IOS_EXPORT_OPTIONS_PLIST")
+            elif [[ -n "$IOS_EXPORT_METHOD" ]]; then
+              args+=("--export-method" "$IOS_EXPORT_METHOD")
+            fi
+            flutter build ipa "${args[@]}"
+            deployable="ipa"
+          else
+            flutter build ios "${common_args[@]}" --no-codesign
+            mkdir -p build/ios/smoke
+            if [[ -d build/ios/iphoneos ]]; then
+              (cd build/ios/iphoneos && zip -qry ../smoke/unsigned-ios-app.zip .)
+            fi
+          fi
+          while IFS= read -r f; do artifacts+=("$f"); done < <(find build/ios -type f \( -name '*.ipa' -o -name '*.xcarchive.zip' -o -name 'unsigned-ios-app.zip' \) 2>/dev/null | sort)
+          apk_count=0
+          aab_count=0
+          normalized=$(echo "${IOS_SCHEME}_${IOS_SDK}_${IOS_DESTINATION}" | tr ' ,:=/' '-')
+          if ! printf '%s\n' "${artifacts[@]:-}" | grep -q '\.ipa$'; then deployable="none"; fi
+        else
+          echo "::error::Unsupported platform_type: $PLATFORM_TYPE"
+          exit 1
+        fi
+        if [[ "${#artifacts[@]}" -eq 0 ]]; then
+          echo "::error::No Flutter build artifacts were produced for $PLATFORM_TYPE"
+          exit 1
+        fi
+        mkdir -p build/flutter-metadata
+        manifest_path="build/flutter-metadata/${PLATFORM_TYPE}-artifact-manifest.json"
+        artifact_paths_json=$(printf '%s\n' "${artifacts[@]}" | jq -R . | jq -cs .)
+        sha_json=$(for f in "${artifacts[@]}"; do shasum -a 256 "$f" | awk -v file="$f" '{printf "{\"path\":\"%s\",\"sha256\":\"%s\"}\n", file, $1}'; done | jq -cs .)
+        jq -cn --arg platform "$PLATFORM_TYPE" --arg semver "$semver" --arg package "$package_name" --arg deployable "$deployable" --arg run_id "${GITHUB_RUN_ID:-}" --arg sha "${GITHUB_SHA:-}" --argjson artifacts "$artifact_paths_json" --argjson checksums "$sha_json" \
+          '{platform:$platform, semver:$semver, package_name:$package, deployable_artifact_type:$deployable, workflow_run_id:$run_id, git_sha:$sha, artifacts:$artifacts, checksums:$checksums}' > "$manifest_path"
+        workflow_artifact_name="build_artifacts_${normalized}"
+        target_artifact_name="source_artifacts_target_${normalized}"
+        echo "semver=$semver" >> "$GITHUB_OUTPUT"
+        echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+        echo "artifact_paths_json=$artifact_paths_json" >> "$GITHUB_OUTPUT"
+        echo "artifact_manifest_json=$(jq -c . "$manifest_path")" >> "$GITHUB_OUTPUT"
+        echo "deployable_artifact_type=$deployable" >> "$GITHUB_OUTPUT"
+        echo "workflow_artifact_name=$workflow_artifact_name" >> "$GITHUB_OUTPUT"
+        echo "target_artifact_name=$target_artifact_name" >> "$GITHUB_OUTPUT"
+        echo "artifact_manifest_path=${{ inputs.source_path }}/${{ inputs.project_path }}/$manifest_path" >> "$GITHUB_OUTPUT"
+        echo "ios_ipa_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.ipa$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        echo "android_apk_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.apk$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        echo "android_aab_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.aab$' && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/ci/flutter/config/action.yml
+++ b/ci/flutter/config/action.yml
@@ -1,0 +1,272 @@
+##
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Distributed Under Apache v2.0 License
+#
+name: Get Configuration Values for Flutter Build
+author: cloudopsworks
+description: Get Flutter build configuration and emit platform matrix values
+inputs:
+  source_path:
+    description: 'The path to the source code'
+    required: false
+    default: 'source'
+  environment:
+    description: 'The environment to use for the build'
+    required: true
+  is_pull_request:
+    description: 'Whether this configuration is for a pull request build'
+    required: false
+    default: 'false'
+  platform_override:
+    description: 'Optional comma-separated platform override: android,ios'
+    required: false
+    default: ''
+outputs:
+  flutter_channel:
+    description: 'Flutter channel'
+    value: ${{ steps.config.outputs.flutter_channel }}
+  flutter_version:
+    description: 'Flutter version'
+    value: ${{ steps.config.outputs.flutter_version }}
+  flutter_project_path:
+    description: 'Flutter project path'
+    value: ${{ steps.config.outputs.flutter_project_path }}
+  flutter_target:
+    description: 'Flutter target'
+    value: ${{ steps.config.outputs.flutter_target }}
+  flutter_build_mode:
+    description: 'Flutter build mode'
+    value: ${{ steps.config.outputs.flutter_build_mode }}
+  flutter_platforms:
+    description: 'Configured Flutter platforms JSON array'
+    value: ${{ steps.config.outputs.flutter_platforms }}
+  build_matrix:
+    description: 'GitHub Actions matrix JSON object with include rows'
+    value: ${{ steps.config.outputs.build_matrix }}
+  deploy_matrix:
+    description: 'Deployable platform matrix JSON object with include rows'
+    value: ${{ steps.config.outputs.deploy_matrix }}
+  matrix_fail_fast:
+    description: 'Matrix fail-fast flag'
+    value: ${{ steps.config.outputs.matrix_fail_fast }}
+  android_enabled:
+    description: 'Whether Android builds are enabled'
+    value: ${{ steps.config.outputs.android_enabled }}
+  ios_enabled:
+    description: 'Whether iOS builds are enabled'
+    value: ${{ steps.config.outputs.ios_enabled }}
+  quality_enabled:
+    description: 'Whether quality checks are enabled'
+    value: ${{ steps.config.outputs.quality_enabled }}
+  analyze_enabled:
+    description: 'Whether flutter analyze is enabled'
+    value: ${{ steps.config.outputs.analyze_enabled }}
+  test_enabled:
+    description: 'Whether flutter test is enabled'
+    value: ${{ steps.config.outputs.test_enabled }}
+  coverage_enabled:
+    description: 'Whether coverage is enabled'
+    value: ${{ steps.config.outputs.coverage_enabled }}
+  formatter_check_enabled:
+    description: 'Whether dart format check is enabled'
+    value: ${{ steps.config.outputs.formatter_check_enabled }}
+  dart_defines_json:
+    description: 'Dart defines JSON array'
+    value: ${{ steps.config.outputs.dart_defines_json }}
+  flutter_extra_args:
+    description: 'Extra Flutter arguments'
+    value: ${{ steps.config.outputs.flutter_extra_args }}
+  linux_runner_set:
+    description: 'Runner for Linux/common jobs'
+    value: ${{ steps.config.outputs.linux_runner_set }}
+  macos_runner_set:
+    description: 'Runner for macOS/iOS jobs'
+    value: ${{ steps.config.outputs.macos_runner_set }}
+  android_artifact_types:
+    description: 'Android artifact types JSON array'
+    value: ${{ steps.config.outputs.android_artifact_types }}
+  android_split_per_abi:
+    description: 'Whether Android split-per-ABI is enabled'
+    value: ${{ steps.config.outputs.android_split_per_abi }}
+  android_sdk:
+    description: 'Android deploy SDK/dimension value'
+    value: ${{ steps.config.outputs.android_sdk }}
+  android_destination:
+    description: 'Android deploy destination/dimension value'
+    value: ${{ steps.config.outputs.android_destination }}
+  android_configuration:
+    description: 'Android configuration'
+    value: ${{ steps.config.outputs.android_configuration }}
+  ios_codesign:
+    description: 'Whether iOS signing is enabled'
+    value: ${{ steps.config.outputs.ios_codesign }}
+  ios_unsigned:
+    description: 'Whether iOS unsigned build is enabled'
+    value: ${{ steps.config.outputs.ios_unsigned }}
+  ios_scheme:
+    description: 'iOS/Xcode scheme'
+    value: ${{ steps.config.outputs.ios_scheme }}
+  ios_sdk:
+    description: 'iOS SDK'
+    value: ${{ steps.config.outputs.ios_sdk }}
+  ios_destination:
+    description: 'iOS destination'
+    value: ${{ steps.config.outputs.ios_destination }}
+  ios_configuration:
+    description: 'iOS configuration'
+    value: ${{ steps.config.outputs.ios_configuration }}
+  ios_export_method:
+    description: 'iOS export method'
+    value: ${{ steps.config.outputs.ios_export_method }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve Flutter configuration
+      id: config
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        IS_PULL_REQUEST: ${{ inputs.is_pull_request }}
+        PLATFORM_OVERRIDE: ${{ inputs.platform_override }}
+      run: |
+        set -euo pipefail
+        global='.cloudopsworks/vars/inputs-global.yaml'
+        envfile=".cloudopsworks/vars/inputs-${ENVIRONMENT}.yaml"
+        if [[ ! -f "$global" ]]; then
+          echo "::error::Missing $global"
+          exit 1
+        fi
+        yqv() {
+          local expr="$1" def="$2"
+          local val=""
+          if [[ -f "$envfile" ]]; then
+            val=$(yq e "$expr // \"__NULL__\"" "$envfile")
+          fi
+          if [[ -z "$val" || "$val" == "null" || "$val" == "__NULL__" ]]; then
+            val=$(yq e "$expr // $def" "$global")
+          fi
+          [[ "$val" == "null" ]] && val=""
+          printf '%s' "$val"
+        }
+        yqj() {
+          local expr="$1" def="$2"
+          local val=""
+          if [[ -f "$envfile" ]]; then
+            val=$(yq e -o=json -I=0 "$expr // null" "$envfile")
+          fi
+          if [[ -z "$val" || "$val" == "null" ]]; then
+            val=$(yq e -o=json -I=0 "$expr // $def" "$global")
+          fi
+          [[ -z "$val" || "$val" == "null" ]] && val="$def"
+          printf '%s' "$val"
+        }
+        bool() {
+          case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+            true|yes|y|1|on) printf 'true' ;;
+            *) printf 'false' ;;
+          esac
+        }
+        csv_to_json() {
+          jq -cn --arg csv "$1" '$csv | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))'
+        }
+
+        flutter_channel=$(yqv '.flutter.channel' '"stable"')
+        flutter_version=$(yqv '.flutter.version' '""')
+        project_path=$(yqv '.flutter.project_path' '"."')
+        target=$(yqv '.flutter.target' '"lib/main.dart"')
+        build_mode=$(yqv '.flutter.build_mode' '"release"')
+        extra_args=$(yqv '.flutter.extra_args' '""')
+        dart_defines=$(yqj '.flutter.dart_defines' '[]')
+        platforms=$(yqj '.flutter.platforms' '["android"]')
+        if [[ -n "$PLATFORM_OVERRIDE" ]]; then
+          platforms=$(csv_to_json "$PLATFORM_OVERRIDE")
+        fi
+
+        quality_enabled=$(bool "$(yqv '.flutter.quality.enabled' '"true"')")
+        analyze_enabled=$(bool "$(yqv '.flutter.quality.analyze' '"true"')")
+        test_enabled=$(bool "$(yqv '.flutter.quality.test' '"true"')")
+        coverage_enabled=$(bool "$(yqv '.flutter.quality.coverage' '"false"')")
+        formatter_check_enabled=$(bool "$(yqv '.flutter.quality.formatter_check' '"false"')")
+        fail_fast=$(bool "$(yqv '.flutter.matrix.fail_fast' '"false"')")
+
+        pr_android=$(bool "$(yqv '.flutter.matrix.pr.include_android' '"true"')")
+        pr_ios=$(bool "$(yqv '.flutter.matrix.pr.include_ios' '"false"')")
+
+        android_enabled=$(bool "$(yqv '.flutter.matrix.android.enabled' '"true"')")
+        android_runner=$(yqv '.flutter.matrix.android.runner_set' '"ubuntu-latest"')
+        android_sdk=$(yqv '.flutter.matrix.android.sdk // .android.sdks[0]' '"android"')
+        android_destination=$(yqv '.flutter.matrix.android.destination // .android.destinations[0]' '"universal"')
+        android_configuration=$(yqv '.flutter.matrix.android.configuration // .android.configuration' '"Release"')
+        android_artifact_types=$(yqj '.flutter.matrix.android.artifact_types' '["apk"]')
+        android_split_per_abi=$(bool "$(yqv '.flutter.matrix.android.split_per_abi' '"false"')")
+        android_build_args=$(yqv '.flutter.matrix.android.build_args' '""')
+        android_deployable=$(yqv '.flutter.matrix.android.deployable_artifact_type' '"apk"')
+
+        ios_enabled=$(bool "$(yqv '.flutter.matrix.ios.enabled' '"false"')")
+        ios_runner=$(yqv '.flutter.matrix.ios.runner_set' '"macos-latest"')
+        ios_xcode_version=$(yqv '.flutter.matrix.ios.xcode_version // .xcode.version' '""')
+        ios_scheme=$(yqv '.flutter.matrix.ios.scheme // .xcode.schemes[0]' '"Runner"')
+        ios_sdk=$(yqv '.flutter.matrix.ios.sdk // .xcode.sdks[0]' '"iphoneos"')
+        ios_destination=$(yqv '.flutter.matrix.ios.destination // .xcode.destinations[0]' '"generic/platform=iOS"')
+        ios_configuration=$(yqv '.flutter.matrix.ios.configuration // .xcode.configuration' '"Release"')
+        ios_codesign=$(bool "$(yqv '.flutter.matrix.ios.codesign // (.xcode.unsigned == false)' '"false"')")
+        ios_unsigned=$(bool "$(yqv '.flutter.matrix.ios.unsigned // .xcode.unsigned' '"true"')")
+        ios_export_method=$(yqv '.flutter.matrix.ios.export_method // .xcode.export_options.method' '"ad-hoc"')
+        ios_export_options_plist=$(yqv '.flutter.matrix.ios.export_options_plist' '""')
+        ios_build_for_testing=$(bool "$(yqv '.flutter.matrix.ios.build_for_testing' '"false"')")
+        ios_build_args=$(yqv '.flutter.matrix.ios.build_args' '""')
+        ios_deployable=$(yqv '.flutter.matrix.ios.deployable_artifact_type' '"ipa"')
+
+        build_matrix=$(jq -cn \
+          --argjson platforms "$platforms" \
+          --arg is_pr "$IS_PULL_REQUEST" \
+          --arg pr_android "$pr_android" --arg pr_ios "$pr_ios" \
+          --arg android_enabled "$android_enabled" --arg android_runner "$android_runner" --arg android_sdk "$android_sdk" --arg android_destination "$android_destination" --arg android_configuration "$android_configuration" --argjson android_artifact_types "$android_artifact_types" --arg android_split_per_abi "$android_split_per_abi" --arg android_build_args "$android_build_args" --arg android_deployable "$android_deployable" \
+          --arg ios_enabled "$ios_enabled" --arg ios_runner "$ios_runner" --arg ios_xcode_version "$ios_xcode_version" --arg ios_scheme "$ios_scheme" --arg ios_sdk "$ios_sdk" --arg ios_destination "$ios_destination" --arg ios_configuration "$ios_configuration" --arg ios_codesign "$ios_codesign" --arg ios_unsigned "$ios_unsigned" --arg ios_export_method "$ios_export_method" --arg ios_export_options_plist "$ios_export_options_plist" --arg ios_build_for_testing "$ios_build_for_testing" --arg ios_build_args "$ios_build_args" --arg ios_deployable "$ios_deployable" '
+          def hasp($p): $platforms | index($p) != null;
+          {include: ([
+            (if hasp("android") and $android_enabled == "true" and ($is_pr != "true" or $pr_android == "true") then {
+              platform_type:"android", runner_set:$android_runner, android_sdk:$android_sdk, android_destination:$android_destination, android_configuration:$android_configuration, artifact_types:$android_artifact_types, android_split_per_abi:$android_split_per_abi, android_build_args:$android_build_args, deployable_artifact_type:$android_deployable
+            } else empty end),
+            (if hasp("ios") and $ios_enabled == "true" and ($is_pr != "true" or $pr_ios == "true") then {
+              platform_type:"ios", runner_set:$ios_runner, xcode_version:$ios_xcode_version, xcode_scheme:$ios_scheme, xcode_sdk:$ios_sdk, xcode_destination:$ios_destination, xcode_configuration:$ios_configuration, ios_codesign:$ios_codesign, ios_unsigned:$ios_unsigned, ios_export_method:$ios_export_method, ios_export_options_plist:$ios_export_options_plist, ios_build_for_testing:$ios_build_for_testing, ios_build_args:$ios_build_args, deployable_artifact_type:(if $ios_codesign == "true" then $ios_deployable else "none" end)
+            } else empty end)
+          ])}' )
+        deploy_matrix=$(jq -cn --argjson rows "$(jq -c '.include' <<<"$build_matrix")" '{include: ($rows | map(select(.deployable_artifact_type == "apk" or .deployable_artifact_type == "ipa")))}')
+
+        {
+          echo "flutter_channel=$flutter_channel"
+          echo "flutter_version=$flutter_version"
+          echo "flutter_project_path=$project_path"
+          echo "flutter_target=$target"
+          echo "flutter_build_mode=$build_mode"
+          echo "flutter_platforms=$platforms"
+          echo "build_matrix=$build_matrix"
+          echo "deploy_matrix=$deploy_matrix"
+          echo "matrix_fail_fast=$fail_fast"
+          echo "android_enabled=$android_enabled"
+          echo "ios_enabled=$ios_enabled"
+          echo "quality_enabled=$quality_enabled"
+          echo "analyze_enabled=$analyze_enabled"
+          echo "test_enabled=$test_enabled"
+          echo "coverage_enabled=$coverage_enabled"
+          echo "formatter_check_enabled=$formatter_check_enabled"
+          echo "dart_defines_json=$dart_defines"
+          echo "flutter_extra_args=$extra_args"
+          echo "linux_runner_set=$android_runner"
+          echo "macos_runner_set=$ios_runner"
+          echo "android_artifact_types=$android_artifact_types"
+          echo "android_split_per_abi=$android_split_per_abi"
+          echo "android_sdk=$android_sdk"
+          echo "android_destination=$android_destination"
+          echo "android_configuration=$android_configuration"
+          echo "ios_codesign=$ios_codesign"
+          echo "ios_unsigned=$ios_unsigned"
+          echo "ios_scheme=$ios_scheme"
+          echo "ios_sdk=$ios_sdk"
+          echo "ios_destination=$ios_destination"
+          echo "ios_configuration=$ios_configuration"
+          echo "ios_export_method=$ios_export_method"
+        } >> "$GITHUB_OUTPUT"

--- a/ci/flutter/quality/action.yml
+++ b/ci/flutter/quality/action.yml
@@ -1,0 +1,76 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Flutter Quality Checks
+author: cloudopsworks
+description: Run Flutter dependency, format, analyzer, and test checks
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  project_path:
+    required: false
+    default: '.'
+    description: 'Flutter project path relative to source_path'
+  target:
+    required: false
+    default: 'lib/main.dart'
+    description: 'Flutter target'
+  pub_get_enabled:
+    required: false
+    default: 'true'
+    description: 'Run flutter pub get'
+  analyze_enabled:
+    required: false
+    default: 'true'
+    description: 'Run flutter analyze'
+  test_enabled:
+    required: false
+    default: 'true'
+    description: 'Run flutter test'
+  coverage_enabled:
+    required: false
+    default: 'false'
+    description: 'Run tests with coverage'
+  formatter_check_enabled:
+    required: false
+    default: 'false'
+    description: 'Run dart format check'
+outputs:
+  coverage_path:
+    description: 'Coverage file path if produced'
+    value: ${{ steps.quality.outputs.coverage_path }}
+  quality_ran:
+    description: 'Whether quality action ran'
+    value: ${{ steps.quality.outputs.quality_ran }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Flutter quality checks
+      id: quality
+      shell: bash
+      working-directory: ${{ inputs.source_path }}/${{ inputs.project_path }}
+      run: |
+        set -euo pipefail
+        if [[ "${{ inputs.pub_get_enabled }}" == "true" ]]; then
+          flutter pub get
+        fi
+        if [[ "${{ inputs.formatter_check_enabled }}" == "true" ]]; then
+          dart format --set-exit-if-changed .
+        fi
+        if [[ "${{ inputs.analyze_enabled }}" == "true" ]]; then
+          flutter analyze
+        fi
+        if [[ "${{ inputs.test_enabled }}" == "true" ]]; then
+          if [[ "${{ inputs.coverage_enabled }}" == "true" ]]; then
+            flutter test --coverage
+          else
+            flutter test
+          fi
+        fi
+        coverage=""
+        if [[ -f coverage/lcov.info ]]; then
+          coverage="${{ inputs.source_path }}/${{ inputs.project_path }}/coverage/lcov.info"
+        fi
+        echo "coverage_path=$coverage" >> "$GITHUB_OUTPUT"
+        echo "quality_ran=true" >> "$GITHUB_OUTPUT"

--- a/ci/flutter/release-assets/action.yml
+++ b/ci/flutter/release-assets/action.yml
@@ -1,0 +1,75 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Collect Flutter Release Assets
+author: cloudopsworks
+description: Download Flutter workflow artifacts and prepare release globs/manifest
+inputs:
+  artifacts_pattern:
+    required: false
+    default: 'build_artifacts_*'
+    description: 'Artifact name pattern to download'
+  output_dir:
+    required: false
+    default: 'release-assets'
+    description: 'Output directory for normalized release assets'
+  manifest_name:
+    required: false
+    default: 'manifest.json'
+    description: 'Manifest file name'
+outputs:
+  files_globs:
+    description: 'Newline-delimited release file globs'
+    value: ${{ steps.collect.outputs.files_globs }}
+  manifest_path:
+    description: 'Manifest path'
+    value: ${{ steps.collect.outputs.manifest_path }}
+  artifact_count:
+    description: 'Number of release assets found'
+    value: ${{ steps.collect.outputs.artifact_count }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Download Flutter build artifacts
+      uses: actions/download-artifact@v7
+      with:
+        pattern: ${{ inputs.artifacts_pattern }}
+        path: .flutter-release-downloads
+        merge-multiple: false
+
+    - name: Normalize release assets
+      id: collect
+      shell: bash
+      run: |
+        set -euo pipefail
+        out="${{ inputs.output_dir }}"
+        mkdir -p "$out/android" "$out/ios"
+        count=0
+        while IFS= read -r f; do
+          case "$f" in
+            *.apk) cp "$f" "$out/android/"; count=$((count+1)) ;;
+            *.aab) cp "$f" "$out/android/"; count=$((count+1)) ;;
+            *.ipa) cp "$f" "$out/ios/"; count=$((count+1)) ;;
+          esac
+        done < <(find .flutter-release-downloads -type f \( -name '*.apk' -o -name '*.aab' -o -name '*.ipa' \) | sort)
+        manifests=()
+        while IFS= read -r f; do manifests+=("$f"); done < <(find .flutter-release-downloads -type f -name 'artifact-manifest.json' | sort)
+        if [[ "${#manifests[@]}" -gt 0 ]]; then
+          jq -s '{artifacts: .}' "${manifests[@]}" > "$out/${{ inputs.manifest_name }}"
+        else
+          jq -n '{artifacts: []}' > "$out/${{ inputs.manifest_name }}"
+        fi
+        files_globs=$(printf '%s\n%s\n%s\n%s\n' \
+          "$out/**/*.apk" \
+          "$out/**/*.aab" \
+          "$out/**/*.ipa" \
+          "$out/${{ inputs.manifest_name }}")
+        {
+          echo "files_globs<<EOF"
+          echo "$files_globs"
+          echo "EOF"
+          echo "manifest_path=$out/${{ inputs.manifest_name }}"
+          echo "artifact_count=$count"
+        } >> "$GITHUB_OUTPUT"
+        if [[ "$count" -eq 0 ]]; then
+          echo "::warning::No APK/AAB/IPA release assets found"
+        fi

--- a/ci/flutter/scan/dtrack/action.yml
+++ b/ci/flutter/scan/dtrack/action.yml
@@ -1,0 +1,68 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: DependencyTrack Scan Flutter
+author: cloudopsworks
+description: Generate or collect Flutter SBOM and upload to DependencyTrack
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  dtrack_url:
+    required: true
+    description: 'DependencyTrack URL'
+  dtrack_token:
+    required: true
+    description: 'DependencyTrack token'
+  dtrack_project_key:
+    required: true
+    description: 'DependencyTrack project key'
+  project_type:
+    required: false
+    default: 'Application'
+    description: 'DependencyTrack project type'
+  semver:
+    required: true
+    description: 'Semantic version'
+  token:
+    required: false
+    default: ${{ github.token }}
+    description: 'GitHub token'
+runs:
+  using: 'composite'
+  steps:
+    - name: Prepare Flutter SBOM
+      id: sbom
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      run: |
+        set -euo pipefail
+        mkdir -p build/sbom
+        bom="build/sbom/bom.json"
+        if [[ -f "$bom" ]]; then
+          :
+        elif command -v cdxgen >/dev/null 2>&1; then
+          cdxgen -t dart -o "$bom" . || cdxgen -o "$bom" .
+        elif command -v cyclonedx-py >/dev/null 2>&1; then
+          cyclonedx-py environment -o "$bom" || true
+        fi
+        if [[ ! -s "$bom" ]]; then
+          deps=$(if [[ -f pubspec.lock ]]; then yq e -o=json '.packages // {}' pubspec.lock 2>/dev/null || echo '{}'; else echo '{}'; fi)
+          jq -n --arg name "${{ inputs.dtrack_project_key }}" --arg version "${{ inputs.semver }}" --argjson deps "$deps" '{bomFormat:"CycloneDX", specVersion:"1.5", version:1, metadata:{component:{type:"application", name:$name, version:$version}}, components: ($deps | to_entries | map({type:"library", name:.key, version:(.value.version // "0.0.0")}))}' > "$bom"
+        fi
+        echo "bom_path=$bom" >> "$GITHUB_OUTPUT"
+
+    - name: SBOM Dtrack Upload
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      run: |
+        set -euo pipefail
+        curl -X POST "https://${{ inputs.dtrack_url }}/api/v1/bom" \
+             -H 'Content-Type: multipart/form-data' \
+             -H 'X-API-Key: ${{ inputs.dtrack_token }}' \
+             -F "autoCreate=true" \
+             -F "projectName=${{ inputs.dtrack_project_key }}" \
+             -F "projectVersion=${{ inputs.semver }}" \
+             -F "parentName=${{ inputs.dtrack_project_key }}" \
+             -F "projectClassifier=${{ inputs.project_type }}" \
+             -F "bom=@${{ steps.sbom.outputs.bom_path }}"

--- a/ci/flutter/scan/semgrep/action.yml
+++ b/ci/flutter/scan/semgrep/action.yml
@@ -1,0 +1,61 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Semgrep Scan Flutter
+author: cloudopsworks
+description: Scan Flutter/Dart and native mobile code with Semgrep
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  semgrep_token:
+    required: true
+    description: 'Semgrep token'
+  bot_user:
+    required: true
+    description: 'Bot user'
+  token:
+    required: true
+    description: 'GitHub token'
+  semgrep_excludes:
+    required: false
+    default: '.github/workflows/*,build/*,.dart_tool/*,ios/Pods/*,android/.gradle/*'
+    description: 'Comma-separated semgrep excludes'
+runs:
+  using: 'composite'
+  steps:
+    - name: Check GHAS Enabled
+      id: check_ghas
+      uses: cloudopsworks/blueprints/ci/common/advancedsecurity/check@v5.10
+      with:
+        token: ${{ inputs.token }}
+
+    - name: Build Semgrep excludes
+      id: excludes
+      shell: bash
+      run: |
+        result=""
+        IFS=',' read -ra parts <<< "${{ inputs.semgrep_excludes }}"
+        for part in "${parts[@]}"; do
+          part=$(echo "$part" | xargs)
+          [[ -n "$part" ]] && result="$result --exclude '$part'"
+        done
+        echo "result=$result" >> "$GITHUB_OUTPUT"
+
+    - name: Semgrep Code Scanning
+      env:
+        SEMGREP_APP_TOKEN: ${{ inputs.semgrep_token }}
+      working-directory: ${{ inputs.source_path }}
+      shell: bash
+      run: |
+        semgrep ci --text --output=semgrep.txt --json-output=semgrep-ci.json --sarif-output=semgrep.sarif ${{ steps.excludes.outputs.result }}
+
+    - name: Upload SARIF file
+      if: |
+        (success() || failure()) &&
+        (steps.check_ghas.outputs.ghas_enabled == 'true')
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        checkout_path: ${{ inputs.source_path }}
+        sarif_file: ${{ inputs.source_path }}/semgrep.sarif
+        wait-for-processing: false

--- a/ci/flutter/scan/snyk/action.yml
+++ b/ci/flutter/scan/snyk/action.yml
@@ -1,0 +1,38 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Snyk Scan Flutter
+author: cloudopsworks
+description: Scan Flutter pub dependencies with Snyk when the CLI is available
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  snyk_token:
+    required: true
+    description: 'Snyk token'
+  bot_user:
+    required: true
+    description: 'Bot user'
+  token:
+    required: true
+    description: 'GitHub token'
+  semver:
+    required: false
+    default: ''
+    description: 'Semantic version'
+runs:
+  using: 'composite'
+  steps:
+    - name: Snyk Flutter Scan
+      env:
+        SNYK_TOKEN: ${{ inputs.snyk_token }}
+      working-directory: ${{ inputs.source_path }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v snyk >/dev/null 2>&1; then
+          echo "::warning::snyk CLI is not installed; skipping Flutter Snyk scan."
+          exit 0
+        fi
+        snyk test --file=pubspec.yaml || snyk test

--- a/ci/flutter/scan/sonarqube/action.yml
+++ b/ci/flutter/scan/sonarqube/action.yml
@@ -1,0 +1,65 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: SonarQube Scan Flutter
+author: cloudopsworks
+description: Scan Flutter/Dart projects with SonarQube
+inputs:
+  source_path:
+    required: false
+    default: 'source'
+    description: 'The path to the source code'
+  sonarqube_url:
+    required: true
+    description: 'SonarQube URL'
+  sonarqube_token:
+    required: true
+    description: 'SonarQube token'
+  sonarqube_project_key:
+    required: true
+    description: 'SonarQube project key'
+  semver:
+    required: true
+    description: 'Semantic version'
+  token:
+    required: false
+    default: ${{ github.token }}
+    description: 'GitHub token'
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Repository Owner
+      id: repo_owner
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      run: |
+        echo "result=$(yq e '.repository_owner // "${{ github.repository_owner }}"' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve SonarQube Flutter settings
+      id: settings
+      shell: bash
+      working-directory: ${{ inputs.source_path }}
+      run: |
+        echo "sources=$(yq e '.sonarqube.sources_path // "lib"' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+        echo "tests=$(yq e '.sonarqube.tests_path // "test"' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+        echo "test_inclusions=$(yq e '.sonarqube.tests_inclusions // "test/**/*"' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+        echo "exclusions=$(yq e '.sonarqube.exclusions // "build/**,.dart_tool/**,ios/Pods/**,android/.gradle/**"' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+        echo "branch_disabled=$(yq e '.sonarqube.branch_disabled and true' .cloudopsworks/vars/inputs-global.yaml)" >> "$GITHUB_OUTPUT"
+        if [[ -f coverage/lcov.info ]]; then echo "lcov=coverage/lcov.info" >> "$GITHUB_OUTPUT"; else echo "lcov=" >> "$GITHUB_OUTPUT"; fi
+
+    - name: SonarQube Scan
+      uses: sonarsource/sonarqube-scan-action@v7
+      env:
+        SONAR_TOKEN: ${{ inputs.sonarqube_token }}
+        SONAR_HOST_URL: ${{ inputs.sonarqube_url }}
+      with:
+        projectBaseDir: ${{ inputs.source_path }}
+        args: >
+          -Dsonar.projectKey=${{ contains(inputs.sonarqube_url, 'sonarcloud.io') && format('{0}_{1}',steps.repo_owner.outputs.result,inputs.sonarqube_project_key) || inputs.sonarqube_project_key }}
+          -Dsonar.projectVersion=${{ inputs.semver }}
+          -Dsonar.sources=${{ steps.settings.outputs.sources }}
+          -Dsonar.tests=${{ steps.settings.outputs.tests }}
+          -Dsonar.test.inclusions=${{ steps.settings.outputs.test_inclusions }}
+          -Dsonar.exclusions=${{ steps.settings.outputs.exclusions }}
+          -Dsonar.dart.lcov.reportPaths=${{ steps.settings.outputs.lcov }}
+          ${{ contains(inputs.sonarqube_url, 'sonarcloud.io') && format('-Dsonar.organization={0}',steps.repo_owner.outputs.result) || ' ' }}
+          ${{ steps.settings.outputs.branch_disabled != 'true' && format('-Dsonar.branch.name={0}',github.ref_name) || ' ' }}

--- a/ci/flutter/setup/action.yml
+++ b/ci/flutter/setup/action.yml
@@ -1,0 +1,73 @@
+##
+# (c) 2021-2026 Cloud Ops Works LLC
+name: Setup Flutter
+author: cloudopsworks
+description: Install Flutter SDK and platform prerequisites
+inputs:
+  source_path:
+    description: 'The path to the source code'
+    required: false
+    default: 'source'
+  flutter_channel:
+    description: 'Flutter channel'
+    required: false
+    default: 'stable'
+  flutter_version:
+    description: 'Flutter version, empty for channel default'
+    required: false
+    default: ''
+  platform_type:
+    description: 'common, android, or ios'
+    required: false
+    default: 'common'
+  cache_enabled:
+    description: 'Enable Flutter/pub cache'
+    required: false
+    default: 'true'
+  precache:
+    description: 'Run flutter precache for the selected platform'
+    required: false
+    default: 'true'
+outputs:
+  flutter_bin:
+    description: 'Flutter binary path'
+    value: ${{ steps.resolve.outputs.flutter_bin }}
+  flutter_version_resolved:
+    description: 'Resolved Flutter version output'
+    value: ${{ steps.resolve.outputs.flutter_version_resolved }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Install runner tools
+      uses: cloudopsworks/blueprints/ci/common/install/runner-tools@v5.10
+      with:
+        source_path: ${{ inputs.source_path }}
+
+    - name: Setup Flutter SDK
+      uses: subosito/flutter-action@v2
+      with:
+        channel: ${{ inputs.flutter_channel != '' && inputs.flutter_channel || 'stable' }}
+        flutter-version: ${{ inputs.flutter_version }}
+        cache: ${{ inputs.cache_enabled }}
+
+    - name: Precache Flutter artifacts
+      if: ${{ inputs.precache == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${{ inputs.platform_type }}" in
+          android) flutter precache --android ;;
+          ios) flutter precache --ios ;;
+          common) flutter precache --android --ios || flutter precache ;;
+          *) flutter precache ;;
+        esac
+
+    - name: Resolve Flutter SDK
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "flutter_bin=$(command -v flutter)" >> "$GITHUB_OUTPUT"
+        echo "flutter_version_resolved<<EOF" >> "$GITHUB_OUTPUT"
+        flutter --version >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Add reusable Flutter config/setup/quality/build/artifact/release asset actions.
- Add Flutter-aware Semgrep, Snyk, SonarQube, and DependencyTrack scan actions.
- Preserve template workflows as thin orchestration over reusable blueprint actions.

+semver: patch

## Validation

- Ruby YAML parse for all ci/flutter action metadata.
- No live GitHub Actions execution in local validation.