### PR TITLE
Fix platform-specific mobile deploy configuration

### DIFF
--- a/cd/deploy/mobile/aws/action.yml
+++ b/cd/deploy/mobile/aws/action.yml
@@ -117,7 +117,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.aws.device_farm_name // ""' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".aws.platforms.${platform}.device_farm_name // .aws.device_farm_name // \"\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Device Farm Pool
@@ -125,7 +126,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.aws.device_farm_pool // ""' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".aws.platforms.${platform}.device_farm_pool // .aws.device_farm_pool // \"\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Test Script Path
@@ -133,7 +135,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.aws.test_script_path // "device_tests"' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".aws.platforms.${platform}.test_script_path // .aws.test_script_path // \"device_tests\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Tests Scripts Available
@@ -156,7 +159,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.aws.test_script_type // "APPIUM_PYTHON_TEST_PACKAGE"' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".aws.platforms.${platform}.test_script_type // .aws.test_script_type // \"APPIUM_PYTHON_TEST_PACKAGE\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Test Script Type for Schedule Run
@@ -300,6 +304,7 @@ runs:
         android_destination: ${{ inputs.android_destination }}
         android_configuration: ${{ inputs.android_configuration }}
         test_script_available: ${{ steps.test_script_available.outputs.result }}
+        test_script_path: ${{ steps.test_script_path.outputs.result }}
         run_test_type: ${{ steps.run_test_type.outputs.result }}
 
     - name: Rename IPA/APK
@@ -408,10 +413,11 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        ff=$(yq e '.aws.device.form_factor' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
-        model=$(yq e '.aws.device.model' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
-        osver=$(yq e '.aws.device.os_version' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
-        max=$(yq e '.aws.device.max_devices' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        ff=$(yq e ".aws.platforms.${platform}.device.form_factor // .aws.device.form_factor" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        model=$(yq e ".aws.platforms.${platform}.device.model // .aws.device.model" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        osver=$(yq e ".aws.platforms.${platform}.device.os_version // .aws.device.os_version" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        max=$(yq e ".aws.platforms.${platform}.device.max_devices // .aws.device.max_devices // 1" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         plat="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'iOS' || 'Android' }}"
         echo "filter={\"filters\":[{\"attribute\":\"PLATFORM\",\"operator\":\"EQUALS\",\"values\":[\"$plat\"]},{\"attribute\":\"FORM_FACTOR\",\"operator\":\"EQUALS\",\"values\":[\"$ff\"]},{\"attribute\":\"MODEL\",\"operator\":\"EQUALS\",\"values\":[\"$model\"]},{\"attribute\":\"OS_VERSION\",\"operator\":\"EQUALS\",\"values\":[\"$osver\"]}],\"maxDevices\":$max}" >> $GITHUB_OUTPUT
 

--- a/cd/deploy/mobile/aws/android/action.yml
+++ b/cd/deploy/mobile/aws/android/action.yml
@@ -51,6 +51,9 @@ inputs:
   test_script_available:
     description: 'The test script availability'
     required: true
+  test_script_path:
+    description: 'The test script path'
+    required: true
   run_test_type:
     description: 'The test script type for the run'
     required: true
@@ -87,8 +90,12 @@ runs:
         rm -f source_artifacts_target.tar
 
     - name: Zip test contents - Android
-      if: ${{ steps.test_script_available.outputs.result == 'true' && ! contains(fromJSON('["ios"]'), inputs.platform_type) }}
-      working-directory: ${{ inputs.source_path }}/${{ steps.test_script_path.outputs.result }}
+      if: ${{ inputs.test_script_available == 'true' }}
+      working-directory: ${{ inputs.source_path }}/${{ inputs.test_script_path }}
       shell: bash
+      env:
+        REL: ${{ inputs.release_name }}
+        RELVER: ${{ inputs.release_version }}
+        QUALI: ${{ inputs.qualifier != '' && '-' || '' }}${{ inputs.qualifier }}
       run: |
         zip -r ${GITHUB_WORKSPACE}/${{ inputs.blueprint_path }}/devicefarms/aws/release/${REL}-${RELVER}${QUALI}-tests.zip .

--- a/cd/deploy/mobile/gcp/action.yml
+++ b/cd/deploy/mobile/gcp/action.yml
@@ -111,7 +111,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.gcp.test_script_path // "device_tests"' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".gcp.platforms.${platform}.test_script_path // .gcp.test_script_path // \"device_tests\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Tests Scripts Available
@@ -134,7 +135,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.gcp.test_script_type // "robo"' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".gcp.platforms.${platform}.test_script_type // .gcp.test_script_type // \"robo\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         echo "result=$res" >> $GITHUB_OUTPUT
 
     - name: Results Bucket Location
@@ -142,7 +144,8 @@ runs:
       working-directory: ${{ inputs.source_path }}
       shell: bash
       run: |
-        res=$(yq e '.gcp.test_lab_bucket // ""' .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        res=$(yq e ".gcp.platforms.${platform}.test_lab_bucket // .gcp.test_lab_bucket // \"\"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml)
         if [[ "$res" != "" ]] ; then
           res="--results-bucket=$res"
         fi
@@ -266,7 +269,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.source_path }}
       run: |
-        devices=$(yq e '.gcp.devices[] | . as $item | "--device \"model=" + $item.model_id + ($item.version_id // "" | select(length > 0) | ",version=" + .) + ($item.locale_id // "" | select(length > 0) | ",locale=" + .) + ($item.orientation // "" | select(length > 0) | ",orientation=" + .) + "\" "' .cloudopsworks/vars/inputs-dev.yaml | tr '\n' ' ')
+        platform="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ios' || 'android' }}"
+        devices=$(yq e ".gcp.platforms.${platform}.devices[]? // .gcp.devices[]? | . as \$item | \"--device \\\"model=\" + \$item.model_id + (\$item.version_id // \"\" | select(length > 0) | \",version=\" + .) + (\$item.locale_id // \"\" | select(length > 0) | \",locale=\" + .) + (\$item.orientation // \"\" | select(length > 0) | \",orientation=\" + .) + \"\\\" \"" .cloudopsworks/vars/inputs-${{ inputs.environment }}.yaml | tr '\n' ' ')
         echo "result=$devices" >> $GITHUB_OUTPUT
 
     - name: Schedule Run - Firebase Test Lab

--- a/cd/deploy/mobile/gcp/android/action.yml
+++ b/cd/deploy/mobile/gcp/android/action.yml
@@ -90,8 +90,12 @@ runs:
         rm -f source_artifacts_target.tar
 
     - name: Zip test contents - Android
-      if: ${{ steps.test_script_available.outputs.result == 'true' && ! contains(fromJSON('["ios"]'), inputs.platform_type) }}
+      if: ${{ inputs.test_script_available == 'true' }}
       working-directory: ${{ inputs.source_path }}/${{ inputs.test_script_path }}
       shell: bash
+      env:
+        REL: ${{ inputs.release_name }}
+        RELVER: ${{ inputs.release_version }}
+        QUALI: ${{ inputs.qualifier != '' && '-' || '' }}${{ inputs.qualifier }}
       run: |
         zip -r ${GITHUB_WORKSPACE}/${{ inputs.blueprint_path }}/devicefarms/gcp/release/${REL}-${RELVER}${QUALI}-tests.zip .


### PR DESCRIPTION
## Summary\n- resolve AWS/GCP mobile provider settings from aws.platforms.<platform> and gcp.platforms.<platform> with flat fallbacks\n- pass Android test script path into the AWS child deploy action\n- fix Android test packaging conditions to use child action inputs\n\n## Semver\n+semver: patch\n\n## Validation\n- ruby YAML parse for mobile action files\n- yq resolution checks for Android/iOS AWS and GCP platform overrides\n\n## Notes\nLive cloud deploy was not run because it requires provider credentials and mobile artifacts.