### PR TITLE
fix: harden Flutter build and artifact uploads +semver: patch

### DIFF
--- a/ci/flutter/artifacts/action.yml
+++ b/ci/flutter/artifacts/action.yml
@@ -65,6 +65,11 @@ runs:
         tar -cf build/flutter-target/source_artifacts_target.tar \
           --exclude='build' --exclude='.dart_tool' --exclude='android/.gradle' --exclude='ios/Pods' --exclude='ios/Flutter/ephemeral' \
           . 2>/dev/null || tar -cf build/flutter-target/source_artifacts_target.tar .
+        project_root="${{ inputs.source_path }}"
+        if [[ -n "${{ inputs.project_path }}" && "${{ inputs.project_path }}" != "." ]]; then
+          project_root="$project_root/${{ inputs.project_path }}"
+        fi
+        echo "project_root=$project_root" >> "$GITHUB_OUTPUT"
         echo "uploaded_artifact_names_json=[\"${{ inputs.workflow_artifact_name }}\",\"${{ inputs.target_artifact_name }}\"]" >> "$GITHUB_OUTPUT"
 
     - name: Upload Flutter build artifacts
@@ -72,17 +77,17 @@ runs:
       with:
         name: ${{ inputs.workflow_artifact_name }}
         path: |
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-upload/files.txt
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-upload/artifact-manifest.json
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/app/outputs/**/*.apk
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/app/outputs/**/*.aab
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/ios/**/*.ipa
-          ${{ inputs.source_path }}/${{ inputs.project_path }}/build/ios/smoke/*.zip
+          ${{ steps.prepare.outputs.project_root }}/build/flutter-upload/files.txt
+          ${{ steps.prepare.outputs.project_root }}/build/flutter-upload/artifact-manifest.json
+          ${{ steps.prepare.outputs.project_root }}/build/app/outputs/**/*.apk
+          ${{ steps.prepare.outputs.project_root }}/build/app/outputs/**/*.aab
+          ${{ steps.prepare.outputs.project_root }}/build/ios/**/*.ipa
+          ${{ steps.prepare.outputs.project_root }}/build/ios/smoke/*.zip
         if-no-files-found: ${{ inputs.if_no_files_found }}
 
     - name: Upload Flutter target bundle
       uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.target_artifact_name }}
-        path: ${{ inputs.source_path }}/${{ inputs.project_path }}/build/flutter-target/source_artifacts_target.tar
+        path: ${{ steps.prepare.outputs.project_root }}/build/flutter-target/source_artifacts_target.tar
         if-no-files-found: error

--- a/ci/flutter/build/action.yml
+++ b/ci/flutter/build/action.yml
@@ -218,7 +218,9 @@ runs:
           [[ -n "$define" && "$define" != "null" ]] && dart_args+=("--dart-define=$define")
         done < <(jq -r '.[]?' <<<"$DART_DEFINES_JSON")
         common_args=("$mode_flag" "--target" "$FLUTTER_TARGET" "--build-name" "$build_name" "--build-number" "$BUILD_NUMBER")
-        common_args+=("${dart_args[@]}")
+        if [[ "${#dart_args[@]}" -gt 0 ]]; then
+          common_args+=("${dart_args[@]}")
+        fi
         if [[ -n "$FLUTTER_EXTRA_ARGS" ]]; then
           # shellcheck disable=SC2206
           extra=( $FLUTTER_EXTRA_ARGS )
@@ -316,7 +318,11 @@ runs:
         echo "deployable_artifact_type=$deployable" >> "$GITHUB_OUTPUT"
         echo "workflow_artifact_name=$workflow_artifact_name" >> "$GITHUB_OUTPUT"
         echo "target_artifact_name=$target_artifact_name" >> "$GITHUB_OUTPUT"
-        echo "artifact_manifest_path=${{ inputs.source_path }}/${{ inputs.project_path }}/$manifest_path" >> "$GITHUB_OUTPUT"
+        project_root="${{ inputs.source_path }}"
+        if [[ -n "${{ inputs.project_path }}" && "${{ inputs.project_path }}" != "." ]]; then
+          project_root="$project_root/${{ inputs.project_path }}"
+        fi
+        echo "artifact_manifest_path=$project_root/$manifest_path" >> "$GITHUB_OUTPUT"
         echo "ios_ipa_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.ipa$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
         echo "android_apk_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.apk$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
         echo "android_aab_available=$(printf '%s\n' "${artifacts[@]}" | grep -q '\.aab$' && echo true || echo false)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary\n- guard empty dart_args expansion for macOS Bash 3 iOS jobs\n- normalize Flutter upload artifact paths when project_path is '.'\n- keep the fix in blueprints so template/sample reuse it\n\n## Validation\n- ruby YAML parse for ci/flutter/build/action.yml and ci/flutter/artifacts/action.yml\n- /bin/bash 3.2 empty dart_args guard smoke check\n- path normalization smoke check\n\nConstraint: patch-only release.\n