### PR TITLE
fix: find nested mobile deploy artifacts +semver: patch

### DIFF
--- a/cd/deploy/mobile/aws/action.yml
+++ b/cd/deploy/mobile/aws/action.yml
@@ -318,9 +318,14 @@ runs:
       run: |
         ext="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ipa' || 'apk' }}"
         app_type="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'IOS_APP' || 'ANDROID_APP' }}"
-        release=$(ls *.$ext 2>/dev/null)
-        echo "Found: $release, moving to: ${REL}-${RELVER}${QUALI}.$ext" 
-        mv "$release" ${REL}-${RELVER}${QUALI}.$ext
+        release=$(find . -type f -name "*.$ext" | head -n 1)
+        if [[ -z "$release" ]]; then
+          echo "::error::No .$ext artifact found under $(pwd)"
+          find . -maxdepth 4 -type f | sort
+          exit 1
+        fi
+        echo "Found: $release, moving to: ${REL}-${RELVER}${QUALI}.$ext"
+        mv "$release" "${REL}-${RELVER}${QUALI}.$ext"
         echo "ext=$ext" >> $GITHUB_OUTPUT
         echo "app_type=$app_type" >> $GITHUB_OUTPUT
 

--- a/cd/deploy/mobile/gcp/action.yml
+++ b/cd/deploy/mobile/gcp/action.yml
@@ -258,9 +258,14 @@ runs:
       run: |
         ext="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'ipa' || 'apk' }}"
         app_type="${{ contains(fromJSON('["ios"]'), inputs.platform_type) && 'IOS_APP' || 'ANDROID_APP' }}"
-        release=$(ls *.$ext 2>/dev/null)
-        echo "Found: $release, moving to: ${REL}-${RELVER}${QUALI}.$ext" 
-        mv "$release" ${REL}-${RELVER}${QUALI}.$ext
+        release=$(find . -type f -name "*.$ext" | head -n 1)
+        if [[ -z "$release" ]]; then
+          echo "::error::No .$ext artifact found under $(pwd)"
+          find . -maxdepth 4 -type f | sort
+          exit 1
+        fi
+        echo "Found: $release, moving to: ${REL}-${RELVER}${QUALI}.$ext"
+        mv "$release" "${REL}-${RELVER}${QUALI}.$ext"
         echo "ext=$ext" >> $GITHUB_OUTPUT
         echo "app_type=$app_type" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Find downloaded mobile build artifacts recursively before Device Farm upload so Flutter-preserved build directories still deploy through the shared mobile AWS/GCP actions.

Constraint: actions/download-artifact preserves uploaded Flutter artifact subdirectories instead of flattening files at the deploy working directory root.
Rejected: changing only Flutter artifact upload to flatten paths | deploy actions should tolerate nested artifacts from all mobile producers.
Confidence: high
Scope-risk: narrow
Directive: keep AWS and GCP mobile deploy artifact discovery behavior aligned.
Tested: ruby YAML parse for cd/deploy/mobile/aws/action.yml and cd/deploy/mobile/gcp/action.yml; bash -n of extracted composite run steps.
Not-tested: remote Device Farm deploy until sample workflows are repinned to this patch tag.
Co-authored-by: OpenAI Codex <codex@openai.com>